### PR TITLE
fixed inline-comment in config.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 # ignore the server configuration file, that is rendered from
 # fabric/templates/server_config.ini
 server_config.ini
+
+# floobits
+.floo

--- a/config.ini
+++ b/config.ini
@@ -1,4 +1,5 @@
 # comma-separated list server names here so that vagrant and fabric
 # can access them from one place.
 [servers]
-virtualbox = fab-tools-start-kit # change this to YourProjectName
+# change this to YourProjectName
+virtualbox = fab-tools-start-kit


### PR DESCRIPTION
really minor but this created a wierd machine name for some reason. aparently python's ini parser does not interpret inline comments
