### PR TITLE
update base box to ubuntu 14.04 LTS "Trusty Tahr"

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,8 +21,8 @@ Vagrant.configure("2") do |config|
   virtualbox_server_name = ini['servers']['virtualbox']
   config.vm.provider :virtualbox do |vb, override_config|
     vb.gui = false
-    override_config.vm.box = "precise32"
-    override_config.vm.box_url = "http://files.vagrantup.com/precise32.box"
+    override_config.vm.box = "trusty64"
+    override_config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
     # override_config.vm.network :forwarded_port, guest: 8000, host: 8000
     # override_config.vm.network :forwarded_port, guest: 80, host: 8080
 


### PR DESCRIPTION
This isn't terribly urgent, but Ubuntu 12.04 is already half-way through its [long term support ("LTS") cycle](https://wiki.ubuntu.com/LTS). Starting to use Ubuntu 14.04 now means that we don't have to worry about OS upgrades for 5 years, which is probably a good thing for our projects moving forward.

For example, a project we did for Northwestern 5 years ago recently upgraded Ubuntu versions and broke a few of our dashboards (which they were able to fix on their own, but still).